### PR TITLE
BP-118: remove http_uri format support

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ codec to decode and [yval](https://github.com/zinid/yval) validator to validate 
 
 The following types are exported from `hapi` module:
 
-- `uri()`: an URI represented in format produced by `http_uri:parse/1` or `uri_string:uri_map()`.
+- `uri()`: an URI represented in format produced by `uri_string:uri_map()`.
 
 - `req_opts()`: a map holding request options. All options are optional.
   Available options are:

--- a/test/hapi_eunit.erl
+++ b/test/hapi_eunit.erl
@@ -432,7 +432,7 @@ make_uri(Host, Port, Path) ->
 
 make_uri(Scheme, Host, Port, Path) ->
     URL = Scheme ++ "://" ++ Host ++ ":" ++ integer_to_list(Port) ++ Path,
-    {ok, URI} = http_uri:parse(URL),
+    URI = uri_string:parse(URL),
     URI.
 
 get_addr_port() ->


### PR DESCRIPTION
As `http_uri` module is deleted from OTP-25, removed all references to `http_uri` types and URI format.