### PR TITLE
add tracing of req/resp

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,9 @@ The following types are exported from `hapi` module:
     cleared with all its pending requests being discarded with the corresponding
     error.
 
+  - `trace: false | {domain, atom()}`: Flag to enable debug logging of request-response pair.
+    Disabled by default. If set, will emit log messages to specified domain.
+
 - `method() :: get | post | delete`: an HTTP method.
 
 - `headers()`: HTTP headers represented as `[{binary(), binary()}]`.

--- a/rebar.config
+++ b/rebar.config
@@ -30,7 +30,7 @@
    [
     unmatched_returns,
     error_handling,
-    race_conditions,
+    % race_conditions,
     unknown
    ]}
  ]}.


### PR DESCRIPTION
Current debug log messages print only IP, hostname and port data. This PR introduces support of tracing calls if `trace` request option is set. 