### PR TITLE
SMST-271: disable default request retries

### DIFF
--- a/src/hapi.erl
+++ b/src/hapi.erl
@@ -34,7 +34,7 @@
 -define(DNS_TIMEOUT, timer:seconds(5)).
 -define(TCP_SEND_TIMEOUT, timer:seconds(5)).
 -define(REQ_TIMEOUT, timer:seconds(30)).
--define(MAX_RETRIES, infinity).
+-define(MAX_RETRIES, 0).
 -define(RETRY_TIMEOUT, timer:seconds(1)).
 
 -type uri() :: uri_string:uri_map().
@@ -161,7 +161,7 @@ req(Method, URI0, Opts) ->
                    {abs, AbsTime} -> AbsTime;
                    Timeout -> hapi_misc:current_time() + Timeout
                end,
-    ReqTimeout = maps:get(timeout_per_request, Opts, infinity),
+    ReqTimeout = maps:get(timeout_per_request, Opts, (DeadLine - hapi_misc:current_time())),
     MaxRetries = maps:get(max_retries, Opts, ?MAX_RETRIES),
     RetryTimeout = maps:get(retry_base_timeout, Opts, ?RETRY_TIMEOUT),
     Families = maps:get(ip_family, Opts, [inet]),

--- a/src/hapi.erl
+++ b/src/hapi.erl
@@ -244,22 +244,13 @@ req(#{uri := #{scheme := Scheme}} = Req, [{Addr, Family}|Addrs], Port, DeadLine,
                           end,
                     erlang:demonitor(MRef),
                     gun:flush(ConnPid),
-                    case Ret of
-                        {ok, _} = OK ->
-                            OK;
-                        {error, {exit, _}} ->
-                            Ret;
-                        {error, NewReason} ->
-                            req(Req, Addrs, Port, DeadLine, ReqTimeout, NewReason)
-                    end;
+                    Ret;
                 {error, Why} ->
-                    req(Req, Addrs, Port, DeadLine, ReqTimeout, prep_reason(Why))
+                    {error, {prep_reason(Why)}}
             end;
         _ ->
             {error, Reason}
-    end;
-req(_, [], _, _, _, Reason) ->
-    {error, Reason}.
+    end.
 
 -spec req(endpoint(), req(), pid(), reference(), hapi_misc:millisecs()) ->
           {ok, http_reply()} | {error, error_reason()}.
@@ -448,7 +439,7 @@ format_method(#{method := Method}) ->
 format(Fmt, Args) ->
     lists:flatten(io_lib:format(Fmt, Args)).
 
--spec format_headers(headers()) -> binary().
+-spec format_headers(headers()) -> iolist().
 format_headers(Headers) ->
     [[N, <<": ">>, V, <<"\r\n">>] || {N, V} <- Headers].
 


### PR DESCRIPTION
Current default retry policy in `hapi` lib is allowing excessive and easy to miss request retries, but retry policy is a feature and should not be enforced by default.