### PR TITLE
USSD-643: Process 201 as success in hapi_json

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -86,7 +86,7 @@
    [{erl_opts, [nowarn_export_all,
                 nowarn_missing_spec]},
     {deps,
-     [meck,
+     [{meck, "0.9.0"},
       {log, {git, "https://github.com/bdt-group/log.git",
              {ref, "3c5c0c301bde516ad34a10d78c39b527b755dea1"}}},
       {conf, {git, "https://github.com/zinid/conf.git",

--- a/src/hapi_json.erl
+++ b/src/hapi_json.erl
@@ -143,7 +143,7 @@ proxy_status(Reason) -> hapi:proxy_status(Reason).
 -spec process_response({ok, hapi:http_reply()} | {error, hapi:error_reason()},
                        yval:validator(T)) ->
                               {ok, T} | {error, error_reason()}.
-process_response({ok, {200, _, Data}}, Validator) ->
+process_response({ok, {Code, _, Data}}, Validator) when Code == 200; Code == 201 ->
     decode(Data, Validator);
 process_response({ok, {204, _, _}}, _) ->
     {ok, no_content};


### PR DESCRIPTION
One of our APIs returns 201 http code with payload, but `hapi_json` recognizes only 200 and 204 codes as successes.   
This MR relaxes http code requirement for `hapi_json` to consider request successful. This is valid according to specs: https://developer.mozilla.org/ru/docs/Web/HTTP/Reference/Status/201 
Also pins `meck` version for OTP23 compat.