### PR TITLE
USSD-805: Add delete with body

### DIFF
--- a/src/hapi.erl
+++ b/src/hapi.erl
@@ -22,7 +22,7 @@
 %% API
 -export([start/0, stop/0]).
 -export([get/1, get/2]).
--export([delete/1, delete/2]).
+-export([delete/1, delete/2, delete/3]).
 -export([post/1, post/2, post/3]).
 -export([put/1, put/2, put/3]).
 -export([format_error/1]).
@@ -99,6 +99,10 @@ delete(URI) ->
 delete(URI, Opts) ->
     req(delete, URI, Opts).
 
+-spec delete(uri(), iodata(), req_opts()) -> {ok, http_reply()} | {error, error_reason()}.
+delete(URI, Body, Opts) ->
+    req({delete, Body}, URI, Opts).
+
 -spec post({uri(), iodata()}) -> {ok, http_reply()} | {error, error_reason()}.
 post({URI, Body}) ->
     post(URI, Body, #{}).
@@ -151,7 +155,7 @@ proxy_status(_) -> 502.
 %%%===================================================================
 %%% Internal functions
 %%%===================================================================
--spec req(get | delete | {post, iodata()} | {put, iodata()}, uri(), req_opts()) ->
+-spec req(get | delete | {post, iodata()} | {put, iodata()} | delete | {delete, iodata()}, uri(), req_opts()) ->
                  {ok, http_reply()} | {error, error_reason()}.
 req(Method, URI0, Opts) ->
     URI = format_uri_map(URI0),
@@ -168,7 +172,7 @@ req(Method, URI0, Opts) ->
     Hdrs = make_headers(URI, Opts),
     Req0 = #{uri => URI, headers => Hdrs},
     Req1 = case Method of
-               {HTTPMethod, Body} when HTTPMethod == post; HTTPMethod == put ->
+               {HTTPMethod, Body} when HTTPMethod == post; HTTPMethod == put; HTTPMethod == delete ->
                    Req0#{method => HTTPMethod, body => Body};
                _ -> Req0#{method => Method}
            end,
@@ -262,6 +266,8 @@ req(AddrPort, Req, ConnPid, MRef, DeadLine) ->
                         gun:get(ConnPid, path_query(URI), Hdrs, ReqOpts);
                     #{method := post, uri := URI, headers := Hdrs, body := Body} ->
                         gun:post(ConnPid, path_query(URI), Hdrs, Body, ReqOpts);
+                    #{method := delete, uri := URI, headers := Hdrs, body := Body} -> % common idiosyncrasy
+                        gun:request(ConnPid, <<"DELETE">>, path_query(URI), Hdrs, Body, ReqOpts);
                     #{method := delete, uri := URI, headers := Hdrs} ->
                         gun:delete(ConnPid, path_query(URI), Hdrs, ReqOpts);
                     #{method := put, uri := URI, headers := Hdrs, body := Body} ->

--- a/src/hapi_json.erl
+++ b/src/hapi_json.erl
@@ -179,9 +179,11 @@ json_to_yaml({Key, Val}) ->
 json_to_yaml(Term) ->
     Term.
 
+-spec set_headers(hapi:method(), hapi:req_opts()) -> hapi:req_opts().
 set_headers(Method, ReqOpts) when Method == post; Method == put -> set_headers(Method, ReqOpts, true);
 set_headers(Method, ReqOpts) -> set_headers(Method, ReqOpts, false).
 
+-spec set_headers(hapi:method(), hapi:req_opts(), boolean()) -> hapi:req_opts().
 set_headers(_, ReqOpts, HasBody) ->
     Hdrs = maps:get(headers, ReqOpts, []),
     Hdrs1 = [{<<"accept">>, <<"application/json, application/problem+json">>}|Hdrs],

--- a/src/hapi_json.erl
+++ b/src/hapi_json.erl
@@ -21,7 +21,7 @@
 
 %% API
 -export([get/2, get/3]).
--export([delete/2, delete/3]).
+-export([delete/2, delete/3, delete/4]).
 -export([post/3, post/4]).
 -export([put/3, put/4]).
 -export([decode/2]).
@@ -67,6 +67,12 @@ delete(URI, Validator) ->
                  {ok, T | no_content} | {error, error_reason()}.
 delete(URI, Validator, Opts) ->
     Ret = hapi:delete(URI, set_headers(delete, Opts)),
+    process_response(Ret, Validator).
+
+-spec delete(hapi:uri(), jiffy:json_value(), yval:validator(T), hapi:req_opts()) ->
+                 {ok, T | no_content} | {error, error_reason()}.
+delete(URI, JSON, Validator, Opts) ->
+    Ret = hapi:delete(URI, encode(JSON), set_headers(delete, Opts, true)),
     process_response(Ret, Validator).
 
 -spec post(hapi:uri(), jiffy:json_value(), yval:validator(T)) ->
@@ -173,15 +179,15 @@ json_to_yaml({Key, Val}) ->
 json_to_yaml(Term) ->
     Term.
 
--spec set_headers(hapi:method(), hapi:req_opts()) -> hapi:req_opts().
-set_headers(Method, ReqOpts) ->
+set_headers(Method, ReqOpts) when Method == post; Method == put -> set_headers(Method, ReqOpts, true);
+set_headers(Method, ReqOpts) -> set_headers(Method, ReqOpts, false).
+
+set_headers(_, ReqOpts, HasBody) ->
     Hdrs = maps:get(headers, ReqOpts, []),
     Hdrs1 = [{<<"accept">>, <<"application/json, application/problem+json">>}|Hdrs],
-    Hdrs2 = case Method of
-                Method when Method == post; Method == put ->
-                    [{<<"content-type">>, <<"application/json">>}|Hdrs1];
-                _ ->
-                    Hdrs1
+    Hdrs2 = case HasBody of
+                true -> [{<<"content-type">>, <<"application/json">>}|Hdrs1];
+                _ ->  Hdrs1
             end,
     ReqOpts#{headers => Hdrs2}.
 

--- a/test/hapi_eunit.erl
+++ b/test/hapi_eunit.erl
@@ -84,6 +84,8 @@ delete_test() ->
     URI = make_uri("/empty-json"),
     ?assertMatch({ok, []},
                  hapi_json:delete(URI, yval:options(#{}))),
+    ?assertMatch({ok, []},
+                 hapi_json:delete(URI, #{}, yval:options(#{}))),
     assert_mailbox().
 
 delete_no_content_test() ->


### PR DESCRIPTION
This MR adds support for delete with body requests.
We have encountered mulitple APIs which use DELETE that requires body with semantic info in it. At this point we have to support it despite it being a grey area of http spec. 
Gun does not provide usual functional interface to do that (like `gun:delete(URI, Body...`), however it has `gun:request` function which can do that, it is in fact the recommended approach: https://github.com/ninenines/gun/issues/119#issuecomment-292808736 
